### PR TITLE
Build kubeconfig from CA stored in secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= cdkbot/capi-control-plane-provider-microk8s:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
+# Components file to be used by clusterctl
+COMPSFILE=control-plane-components.yaml
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -60,6 +62,12 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
+
+.PHONY: component
+component: manifests kustomize ## Produce the control-plane-components.yaml.
+	$(KUSTOMIZE) build config/crd/ > $(COMPSFILE)
+	echo "---" >> $(COMPSFILE)
+	$(KUSTOMIZE) build config/default/ >> $(COMPSFILE)
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: cluster-api-control-plane-provider-microk8s-system
+namespace: capm-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: cluster-api-control-plane-provider-microk8s-
+namePrefix: capi-cp-provider-microk8s-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: docker.io/cdkbot/capi-control-plane-provider-microk8s:latest
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/control-plane-components.yaml
+++ b/control-plane-components.yaml
@@ -1,0 +1,779 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: microk8s
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: microk8scontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MicroK8sControlPlane
+    listKind: MicroK8sControlPlaneList
+    plural: microk8scontrolplanes
+    shortNames:
+    - mcp
+    singular: microk8scontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TalosControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - description: This denotes whether or not the control plane has the uploaded talos-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: Total number of non-terminated machines targeted by this control plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready Replicas
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable Replicas
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MicroK8sControlPlane is the Schema for the microk8scontrolplanes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MicroK8sControlPlaneSpec defines the desired state of MicroK8sControlPlane
+            properties:
+              controlPlaneConfig:
+                description: to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command'
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                    type: object
+                  initConfiguration:
+                    properties:
+                      addons:
+                        description: List of addons to be enabled upon cluster creation
+                        items:
+                          type: string
+                        type: array
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      joinTokenTTLInSecs:
+                        default: 315569260
+                        description: The join token will expire after the specified seconds, defaults to 10 years
+                        format: int64
+                        minimum: 1
+                        type: integer
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      localAPIEndpoint:
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                    type: object
+                type: object
+              machineTemplate:
+                description: 'EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN! NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.'
+                properties:
+                  infrastructureTemplate:
+                    description: InfrastructureTemplate is a required reference to a custom resource offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - infrastructureTemplate
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              version:
+                description: Version defines the desired Kubernetes version.
+                minLength: 2
+                pattern: ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$
+                type: string
+            required:
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: MicroK8sControlPlaneStatus defines the observed state of MicroK8sControlPlane
+            properties:
+              bootstrapped:
+                description: Bootstrapped denotes whether any nodes received bootstrap request which is required to start etcd and Kubernetes components in Talos.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the MicroK8sControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              initialized:
+                description: Initialized denotes whether or not the control plane has the uploaded talos-config configmap.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the TalosControlPlane API Server is ready to receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane machines.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this control plane (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: capm-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: microk8s
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: microk8scontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MicroK8sControlPlane
+    listKind: MicroK8sControlPlaneList
+    plural: microk8scontrolplanes
+    shortNames:
+    - mcp
+    singular: microk8scontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TalosControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - description: This denotes whether or not the control plane has the uploaded talos-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: Total number of non-terminated machines targeted by this control plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready Replicas
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable Replicas
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MicroK8sControlPlane is the Schema for the microk8scontrolplanes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MicroK8sControlPlaneSpec defines the desired state of MicroK8sControlPlane
+            properties:
+              controlPlaneConfig:
+                description: to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command'
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                    type: object
+                  initConfiguration:
+                    properties:
+                      addons:
+                        description: List of addons to be enabled upon cluster creation
+                        items:
+                          type: string
+                        type: array
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      joinTokenTTLInSecs:
+                        default: 315569260
+                        description: The join token will expire after the specified seconds, defaults to 10 years
+                        format: int64
+                        minimum: 1
+                        type: integer
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      localAPIEndpoint:
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                    type: object
+                type: object
+              machineTemplate:
+                description: 'EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN! NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.'
+                properties:
+                  infrastructureTemplate:
+                    description: InfrastructureTemplate is a required reference to a custom resource offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - infrastructureTemplate
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              version:
+                description: Version defines the desired Kubernetes version.
+                minLength: 2
+                pattern: ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$
+                type: string
+            required:
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: MicroK8sControlPlaneStatus defines the observed state of MicroK8sControlPlane
+            properties:
+              bootstrapped:
+                description: Bootstrapped denotes whether any nodes received bootstrap request which is required to start etcd and Kubernetes components in Talos.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the MicroK8sControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              initialized:
+                description: Initialized denotes whether or not the control plane has the uploaded talos-config configmap.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the TalosControlPlane API Server is ready to receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane machines.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this control plane (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capi-cp-provider-microk8s-controller-manager
+  namespace: capm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capi-cp-provider-microk8s-leader-election-role
+  namespace: capm-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: capi-cp-provider-microk8s-manager-role
+  namespace: capm-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: capi-cp-provider-microk8s-manager-role
+rules:
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capi-cp-provider-microk8s-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capi-cp-provider-microk8s-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-cp-provider-microk8s-leader-election-rolebinding
+  namespace: capm-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-cp-provider-microk8s-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-cp-provider-microk8s-controller-manager
+  namespace: capm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capi-cp-provider-microk8s-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-cp-provider-microk8s-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-cp-provider-microk8s-controller-manager
+  namespace: capm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capi-cp-provider-microk8s-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-cp-provider-microk8s-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: capi-cp-provider-microk8s-controller-manager
+  namespace: capm-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 43109c0a.cluster.x-k8s.io
+kind: ConfigMap
+metadata:
+  name: capi-cp-provider-microk8s-manager-config
+  namespace: capm-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: capi-cp-provider-microk8s-controller-manager-metrics-service
+  namespace: capm-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: capi-cp-provider-microk8s-controller-manager
+  namespace: capm-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        image: docker.io/cdkbot/capi-control-plane-provider-microk8s:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: capi-cp-provider-microk8s-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -1,7 +1,15 @@
 package controllers
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"strings"
 	"time"
@@ -24,11 +32,11 @@ import (
 )
 
 const (
-	dummyConfig string = `
+	templateConfig string = `
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lVQnNwdzRSbXNNTUlFRHBJU1BHcjlMSHUyZlgwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0Z6RVZNQk1HQTFVRUF3d01NVEF1TVRVeUxqRTRNeTR4TUI0WERUSXlNRFl4TnpFeU1qVXhPVm9YRFRNeQpNRFl4TkRFeU1qVXhPVm93RnpFVk1CTUdBMVVFQXd3TU1UQXVNVFV5TGpFNE15NHhNSUlCSWpBTkJna3Foa2lHCjl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFxY1lEd3NCbUpMSm1rZXg5bTQ0eCtJMlQ3Q3lvSlFvQ1p4UUEKSGtPRDNiNjhzME9IVWt4dW1YWmUwWHZGOVRQVy9yR0tlb1ZBRUpKMG53eHpEY3M4ZlZ6TXA0UmZ1S1BoL2NmVApOZVJNa2J3WFgxYVgxTXBrTzUxRzdEWm05bG90bVo4Q1V6TnZDaTlwUzBhTzM1WU9EcGh4UGtxT2tYamRuQm5BClhIWFdWUFJqdzZ6UGhYY3dXQVpVMDVlbDhpSFU4Wk1vMlk5eVhaNnhpcWk2Z01lc3p0SlgxQzFVUll6cXRvUU8KeVNrOHNsbUVxMXNRUUQxNjFTTFZsZ3VENy9WSG5LSGZ5bEJyZlFiaUcvcGkxZm5BdnhXYm1ZOG1vc2hpWm4xcwpDazMzbzc2NE93QXk4UFNDVElyNXJnOWJ5TUl2c0h3NkRVZ09qekljSlU2a3V1Z0xRd0lEQVFBQm8xTXdVVEFkCkJnTlZIUTRFRmdRVVBEQUhLYjlGVDdNOEJCREk3WUhtVDNGdmdPWXdId1lEVlIwakJCZ3dGb0FVUERBSEtiOUYKVDdNOEJCREk3WUhtVDNGdmdPWXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txaGtpRzl3MEJBUXNGQUFPQwpBUUVBSHZleWQwc3RGaHFjVERPZ09HMHJaWFcwUjNLRGxwVzc2NkZBRGRwOTZ5UGREeG9xZ2dUQktraDBjZ3Z6CmFub2oxR0JmK0ZFWVFuRjlJb29zbXFZWHlFVTNlU05MU2M1NmVpNTFXeWVDa1BROU9RZnZPejlRU2tDT2lVckgKRXhzVzlQRTZXOTBjSVJ6M0h6RXhHeUtFK1JDZUNqZlpDVmNtTUFXMEVrdVVyeHQvY3JJemhxSlFhNUJOV1hGcwo2cEVTWUFJbGtxY0ROZ3lJbjhhVWMxK2hKdVdRamxXeElRc3FnT09GNG56ZjlLTGNCek1sQ0Q0cFc4ekZWRXg0ClhVWEI1NlhyWGdKMzJJbjBxK045dHlXVkN3STZLdUYxak81blhqU0xDQTRQdkpBcmg3YjFsN2lJOGZxR09yaXQKdGFKTlR5N1pwOTFCclBWN3Nha1A1eFQrbXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    certificate-authority-data: <CACERT>
     server: https://<HOST>:6443
   name: microk8s-cluster
 contexts:
@@ -42,8 +50,8 @@ preferences: {}
 users:
 - name: admin
   user:
-    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN4ekNDQWE4Q0ZCNlVJb0ZQSzVTYnBiNWo0ZWNXa3hvYWkzaW5NQTBHQ1NxR1NJYjNEUUVCQ3dVQU1CY3gKRlRBVEJnTlZCQU1NRERFd0xqRTFNaTR4T0RNdU1UQWVGdzB5TWpBMk1UY3hOVEl4TXpkYUZ3MHpPVEV4TURVeApOVEl4TXpkYU1Da3hEakFNQmdOVkJBTU1CV0ZrYldsdU1SY3dGUVlEVlFRS0RBNXplWE4wWlcwNmJXRnpkR1Z5CmN6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUtqMmZONE8zUkQyWEtPRjJhNlMKUmIxQ3NZckh6eTZ6SFVBWGN6REJKZFYya1hVUWJSRVVaaWtPUkM5c0xnU2NFdFhiOHJpSGxKWG5YWkMzZ3RtUwphNnF4V1MwckFrWTBNREd5SW8xOVlXV2gyZUZvUVZPR1kweFdHeG9kd1BTY0ZoZnhVbVZTbS9ndzlEcFd2MnF3Cm9yV1hLUFlCZU1zeDBrbWdkRnZ0L2hzRXB3ZUt2U3FRYUJ5NGpyYmN2Tk05ZkcrbXJYQ01kY0VDRVRHZGNVTHAKTVB1VTdpcXgyMFkrRWkycWpwTDQwRWxjZVY2MDVzbThrb09mbjhOUFJ0anp5dTYrdFFkb0NRTGJyY2tlZFYyOAp6dmR2b1VJVmlKV25KbmgzaVVLR1F0cUtjMHcrdmVYSXl3blMzL1BMOXUxSmZhb3A0eXZUYjBmNVdQSFRTL244CjI3OENBd0VBQVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWRrdjB5aS9kZkxXbWIxTU0vMklaYUhXcHpjR1QKb2kyS3lHMFJDOGtHQmxNeHZPYjBSY0d0ck9zdzNqdCtyOFU4ODRkZmV5NjI3cTZGZzdSQUxjWHowNk9aMXRCOQpTL3JGaFdGOHM1QlBJaWd1T2g2RWdMeWVoWitUczNzakZDaWdtZU83QWxVdGV0Q0xvWElNZmkwZG5PMzJJbkdUCndtTWR0aEh3c3pkaE10UGFHNG03YUYycmw1a1RSZlJla3NYd3J1M2ZNalR4MC9jdlU5dTF0MDdJbkVRdW5LaSsKbDBlSlFaVVNYNGx3dkJXb0hvYnZpOXdoMW9oSVJpRFZ1OExYS0xWbUZwQ1BuMG0wTzlxRXRUbnZ3Wi9tSk5DOApOL1VQVTMzVi9DZitEK1c1dC9LdG1GUzErQ0I0WW1DYlNkK3BseFdOaVNaY0orajd2MlRITnVVcHhRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBcVBaODNnN2RFUFpjbzRYWnJwSkZ2VUt4aXNmUExyTWRRQmR6TU1FbDFYYVJkUkJ0CkVSUm1LUTVFTDJ3dUJKd1MxZHZ5dUllVWxlZGRrTGVDMlpKcnFyRlpMU3NDUmpRd01iSWlqWDFoWmFIWjRXaEIKVTRaalRGWWJHaDNBOUp3V0YvRlNaVktiK0REME9sYS9hckNpdFpjbzlnRjR5ekhTU2FCMFcrMytHd1NuQjRxOQpLcEJvSExpT3R0eTgwejE4YjZhdGNJeDF3UUlSTVoxeFF1a3crNVR1S3JIYlJqNFNMYXFPa3ZqUVNWeDVYclRtCnlieVNnNStmdzA5RzJQUEs3cjYxQjJnSkF0dXR5UjUxWGJ6TzkyK2hRaFdJbGFjbWVIZUpRb1pDMm9welRENjkKNWNqTENkTGY4OHYyN1VsOXFpbmpLOU52Ui9sWThkTkwrZnpidndJREFRQUJBb0lCQUIzVGpVMWgwRko3T3ZVKwozcU43Zk1ZaExOZ3oxM1lGOW1ibS9OV2hjdjFRdGZLMVdKdUlQMVNHQ1RGWjVuRzMzM2RUSVhERHRrNFVEcWRLClRkWDhpL2NRNFk0Z3BvRWdHMVhhZlZEK3poK3p4NU9MNU9SS3QrSzAzSW5xc0xJOWo0VGdlOHdaSGlGYyt2QUYKZWpycVBYN1MxVTlBQ1VQTllyTE9tVnZWRW1OUVVGaElzV2dhZkVaUndiNUI0UEtmK2toOEZLNngzR1duL0xIbgpCWG5XVU50VENGZjkzZ1dwYkFzc29KcjFCVVMzV1AwcFZaTmhzWWZpWWZoNm0xdnlIYUNNRHgyTXJpakhLZGJJClJOTXViWWFlOHZWQ0x3Q0tlOEloOGxLNWgwc2lZNk1YYlIwT2Mrc3Zaa3JJSkdjWmF3aHZFaU9NSnIxclprZ1AKRFVRK1YrRUNnWUVBM21DU2kzVytXZDNNTXgrdkRCUmtPNWJkdTM3alVKdXptZ1grVVFCY0pZa2hGb08vb1czago3blp1YkpoZ2VZUUhSektHT3NrQm1oV05CVFlLV1IxRnV0WEpwdmp6T1JtSXRYRStBTFVLRml3QUw2U0ZRSDcwCjlpK3U2UFBXS0NXMW5laVRxNnMzU0pGNkFWZTRwUERtRThsYXFTOXovWkUyMU42MEFKQS9yNUVDZ1lFQXdvSnYKWjdRU0VGb3ZOSlFSR0t1SVQ0MUE4U3lxRW92elJKRGRLakxZT0h4WW9kWUh0a2duMDZTaDU1MDVCem5qMXhxcgovVGdpRnQyT1V6eHNLbFJyY2RLWXljY2VySVM0L1Rad1YxK2dKQWJBRU5nK2d6THJ0dzJOcFF6UTJuK0NlbEpSCmc2V1JQcUlqM0xtS1hZZ0s4VWlGaHZwYVRkcVBYTVBhSFd5ZnprOENnWUI3K0F4YUVLYXdSSlNNdjVIL1F2THAKd1Y0VkkxU240RlVNZldEY1dUNEZjdC91UkQ0MVNTU3pFSFRZdDAyNUVHQmFVWkZBL2tPVldZUkhMbXd3WjhBeQp1dkh5MG9BTkNlNExjSGpuUGdYRWZIMFNFajV5eVJQWWxwYUVxVUp2R1M2WlBFbnVmc0dRQkFHbTgvY3NoRnRQCkZvWWpJU0FoY0szSGwrdHpFUGRmOFFLQmdEZFRSSDdaMEQySWVWN2FNdGF5aTY0Yy9uamEvSEVVRDVqVUg2Uk8KSEFSTkVpVE9MUmxqQXJrSFhlbjBaWEV4dlNYRTkyQ3FJOEFmT3NsZ0tXQU03UmJPRVJscm9zVHRaM1RXbERPMgpCbVhZNmE2ZzQzOEw3OUg4YitxZmI1U0dxa1ZDdnQ3VUxERUZpMi9QOHBSU0N0TEFqd0pxbVY4RnFMdDVGY1JDCnpsMnZBb0dBWjZnR1FIcEw2YXpvUkhsZlFkK2prdGo4dFpVNU4xaUtmVEFLMENYMk1CdGJHWUpiOEtNM2NhMGEKVms2MFBHYSs1OWhVTHgzblBSaU5maVBPVXdNS2JFcTBOeFhqbjN5YXRxTnBPcWlQUUlDaEdZQjVmN2IwaGZPUQpaM1orOFZQVHB3OTd1QVBVVUdaUmZPdUhQczFGYzA1TElrNGpxOTRjb0VUK0h2Mm1nNTQ9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+    client-certificate-data: <CERT>
+    client-key-data: <KEY>
 `
 )
 
@@ -89,15 +97,17 @@ func (r *MicroK8sControlPlaneReconciler) kubeconfigForCluster(ctx context.Contex
 		return nil, err
 	}
 	if !found && c.Spec.ControlPlaneEndpoint.IsValid() {
-
-		realDummyConfig := strings.Replace(dummyConfig, "<HOST>", c.Spec.ControlPlaneEndpoint.Host, -1)
+		kubeconfig, err := r.genarateKubeconfig(ctx, cluster, c.Spec.ControlPlaneEndpoint.Host)
+		if err != nil {
+			return nil, err
+		}
 		configsecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cluster.Namespace,
 				Name:      cluster.Name + "-kubeconfig",
 			},
 			Data: map[string][]byte{
-				"value": []byte(realDummyConfig),
+				"value": []byte(*kubeconfig),
 			},
 		}
 		err = r.Client.Create(ctx, configsecret)
@@ -134,6 +144,89 @@ func (r *MicroK8sControlPlaneReconciler) kubeconfigForCluster(ctx context.Contex
 		Clientset: clientset,
 		dialer:    dialer,
 	}, nil
+}
+
+func (r *MicroK8sControlPlaneReconciler) genarateKubeconfig(ctx context.Context, cluster client.ObjectKey, host string) (kubeconfig *string, err error) {
+	// Get the secret with the CA
+	readCASecret := &corev1.Secret{}
+	err = r.Client.Get(ctx,
+		types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Name + "-ca",
+		},
+		readCASecret,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode certificates
+	caCertBlock, _ := pem.Decode(readCASecret.Data["crt"])
+	if caCertBlock == nil || caCertBlock.Type != "CERTIFICATE" {
+		return nil, errors.New("failed to decode CA certificate")
+	}
+
+	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(readCASecret.Data["key"])
+	if block == nil || block.Type != "RSA PRIVATE KEY" {
+		return nil, errors.New("failed to decode CA key")
+	}
+
+	caKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// set up client certificate
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization:  []string{"Canonical"},
+			Country:       []string{"GB"},
+			Province:      []string{""},
+			Locality:      []string{"Canonical"},
+			StreetAddress: []string{"Canonical"},
+			CommonName:    "admin",
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, &certPrivKey.PublicKey, caKey)
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	keyPEM := new(bytes.Buffer)
+	pem.Encode(keyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+
+	config := strings.Replace(templateConfig, "<HOST>", host, -1)
+	config = strings.Replace(config, "<CACERT>", base64.StdEncoding.EncodeToString(readCASecret.Data["crt"]), -1)
+	config = strings.Replace(config, "<CERT>", base64.StdEncoding.EncodeToString(certPEM.Bytes()), -1)
+	config = strings.Replace(config, "<KEY>", base64.StdEncoding.EncodeToString(keyPEM.Bytes()), -1)
+
+	return &config, nil
 }
 
 func (r *MicroK8sControlPlaneReconciler) generateMicroK8sConfig(ctx context.Context, tcp *clusterv1beta1.MicroK8sControlPlane,

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "43109c0a.cluster.x-k8s.io",
+		LeaderElectionID:       "microk8s-control-plane-manager-leader-election-capi",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,10 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+releaseSeries:
+  - major: 0
+    minor: 1
+    contract: v1beta1


### PR DESCRIPTION
The control plane provider will generate the kubeconfig file (stored as a secret for clusterctl to fetch) using a CA stored as a secret by the bootstrap provider.

A user can provide his own set of CA and kubeconfig files by creating thwo secrets named "<cluster-name>-ca" and "<cluster-name>-kubeconfig".