### PR TITLE
add action for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+jobs:
+  build:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Retrieve build information
+        id: build
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          files: |
+            control-plane-components.yaml
+            metadata.yaml
+          generate_release_notes: true
+          draft: true
+          prerelease: ${{ contains(env.VERSION, 'rc') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,17 @@ jobs:
       - name: Retrieve build information
         id: build
         run: |
-          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          VERSION="${GITHUB_REF#refs/tags/}"
+          echo "Releasing ${VERSION}"
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          sed -i "s,docker.io/cdkbot/capi-control-plane-provider-microk8s:latest,cdkbot/capi-control-plane-provider-microk8s:${VERSION//v}," control-plane-components.yaml
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v0.1.14
         with:
+          name: 'Release ${{ env.VERSION }}'
           files: |
             control-plane-components.yaml
             metadata.yaml
           generate_release_notes: true
-          draft: true
+          draft: false
           prerelease: ${{ contains(env.VERSION, 'rc') }}


### PR DESCRIPTION
## Summary

Add a GitHub action workflow that creates releases on tag pushes.

*NOTE*: Releases are pushed as draft at the moment, to facilitate with testing.