### PR TITLE
Fix worker status not updating to Running

### DIFF
--- a/controllers/microk8scontrolplane_controller.go
+++ b/controllers/microk8scontrolplane_controller.go
@@ -164,6 +164,7 @@ func (r *MicroK8sControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl
 			}
 		}
 
+		res = ctrl.Result{RequeueAfter: 30 * time.Second}
 		logger.Info("successfully updated control plane status")
 	}()
 

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -65,7 +65,7 @@ func (r *MicroK8sControlPlaneReconciler) updateStatus(ctx context.Context,
 	if err != nil {
 		log.Info("failed to update provider ID of nodes", "error", err)
 
-		return nil
+		return err
 	}
 
 	nodeSelector := labels.NewSelector()
@@ -113,7 +113,7 @@ func (r *MicroK8sControlPlaneReconciler) updateProviderID(ctx context.Context, c
 	if err != nil {
 		log.Info("failed to list nodes", "error", err)
 
-		return nil
+		return err
 	}
 
 	selector := map[string]string{

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -81,7 +81,7 @@ func (r *MicroK8sControlPlaneReconciler) updateStatus(ctx context.Context,
 	if err != nil {
 		log.Info("failed to list controlplane nodes", "error", err)
 
-		return nil
+		return err
 	}
 
 	for _, node := range nodes.Items {


### PR DESCRIPTION
We make sure we periodically check the status of the cluster node. This was we address the race condition where the worker node provider ID does not get updated. 