### PR TITLE
Use the full canonical name of the docker.io repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/}"
           echo "Releasing ${VERSION}"
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          sed -i "s,docker.io/cdkbot/capi-control-plane-provider-microk8s:latest,cdkbot/capi-control-plane-provider-microk8s:${VERSION//v}," control-plane-components.yaml
+          sed -i "s,docker.io/cdkbot/capi-control-plane-provider-microk8s:latest,docker.io/cdkbot/capi-control-plane-provider-microk8s:${VERSION//v}," control-plane-components.yaml
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v0.1.14
         with:


### PR DESCRIPTION
We need the full canonical name for the image or else clusterctl init is failing with:
```
$ clusterctl init --infrastructure "aws" --bootstrap "microk8s" --control-plane "microk8s"
Fetching providers
Error: failed to get provider components for the "microk8s" provider: failed to apply image overrides: failed to fix containers in deployment capi-microk8s-bootstrap-controller-manager: failed to fix containers: failed to fix image for container manager: couldn't parse image name: repository name must be canonical
```