### PR TITLE
Cleanup the status reconciliation in control plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ golangci-lint: ## Download golangci-lint locally if necessary.
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: microk8scontrolplanes.controlplane.cluster.x-k8s.io
 spec:
@@ -126,6 +126,19 @@ spec:
                           from the endpoint the client submits requests to. Cannot
                           be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                         type: string
+                      localAPIEndpoint:
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
                       noProxy:
                         description: The optional no proxy configuration
                         type: string
@@ -173,6 +186,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                 required:
                 - infrastructureTemplate
                 type: object
@@ -292,9 +306,3 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
Signed-off-by: Sachin Kumar Singh <sachin.singh@canonical.com>

We were using some boilerplate from kubeadm for reconciliation which did requeues even when the status was not ready, but we needed it to see the status of the control plane. We recently had a fix for the control plane for giving ProviderID in which we are now requeuing after every 30 seconds. This takes care of all the default cases for re-queues and hence no longer necessary.

#### Other changes
- Upgraded the controller-gen to the latest v0.10.0 for compatibility with the latest go release. 