### PR TITLE
Added support for control plane upgrades

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -146,7 +146,7 @@ func (r *MicroK8sControlPlaneReconciler) reconcileMachines(ctx context.Context, 
 	var oldVersionMachines []clusterv1.Machine
 	var oldVersion, newVersion string
 
-	if len(machines) > 0 {
+	if numMachines > 0 {
 		sort.Sort(SortByCreationTimestamp(machines))
 		oldVersion = semver.MajorMinor(*machines[0].Spec.Version)
 		newVersion = semver.MajorMinor(mcp.Spec.Version)

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -125,7 +125,7 @@ func (r *MicroK8sControlPlaneReconciler) reconcileMachines(ctx context.Context, 
 
 	controlPlane := r.newControlPlane(cluster, mcp, machines)
 
-	var oldVersionMachines []clusterv1.Machine
+	logger := log.FromContext(ctx).WithValues("desired", desiredReplicas, "existing", numMachines)
 
 	// Assumption: The newer machines are appended at the end of the
 	// machines list, due to list being sorted by creation timestamp.
@@ -142,20 +142,35 @@ func (r *MicroK8sControlPlaneReconciler) reconcileMachines(ctx context.Context, 
 	// 3) When version is changed in b/w upgrades: During this case,
 	// the latest version of machines will be scaled up and all the
 	// older versions will be scaled down.
-	if numMachines == desiredReplicas && numMachines > 0 {
-		sort.Sort(SortByCreationTimestamp(machines))
-		oldVersion := semver.MajorMinor(*machines[0].Spec.Version)
-		newVersion := semver.MajorMinor(*machines[numMachines-1].Spec.Version)
 
-		for idx := 0; idx < numMachines; idx++ {
-			if semver.Compare(oldVersion, newVersion) != 0 {
-				oldVersionMachines = append(oldVersionMachines, machines[idx])
-				break
-			}
-		}
+	var oldVersionMachines []clusterv1.Machine
+	var oldVersion, newVersion string
+
+	if len(machines) > 0 {
+		sort.Sort(SortByCreationTimestamp(machines))
+		oldVersion = semver.MajorMinor(*machines[0].Spec.Version)
+		newVersion = semver.MajorMinor(mcp.Spec.Version)
 	}
 
-	logger := log.FromContext(ctx).WithValues("desired", desiredReplicas, "existing", numMachines)
+	if oldVersion != "" && semver.Compare(oldVersion, newVersion) != 0 {
+
+		oldVersionMachines = append(oldVersionMachines, machines[0])
+
+		// We have a old machine, so we create a new one to increase
+		// the number of machines to one more than the desired number.
+		// This will create an imbalance of one machine and they will
+		// be scaled down to the desired number in the next reconcile.
+
+		if numMachines == desiredReplicas && len(oldVersionMachines) > 0 {
+			conditions.MarkFalse(mcp, clusterv1beta1.ResizedCondition, clusterv1beta1.ScalingUpReason, clusterv1.ConditionSeverityWarning,
+				"Scaling up control plane to %d replicas (actual %d)", desiredReplicas, numMachines)
+
+			// Create a new machine
+			logger.Info("Creating a new node")
+
+			return r.bootControlPlane(ctx, cluster, mcp, controlPlane, false)
+		}
+	}
 
 	switch {
 	// We are creating the first replica
@@ -210,6 +225,7 @@ func (r *MicroK8sControlPlaneReconciler) reconcileMachines(ctx context.Context, 
 				}
 			}
 		}
+
 		return res, err
 	default:
 		if !mcp.Status.Bootstrapped {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+type SortByCreationTimestamp []clusterv1.Machine
+
+func (it SortByCreationTimestamp) Len() int {
+	return len(it)
+}
+func (it SortByCreationTimestamp) Less(i, j int) bool {
+	return it[j].GetCreationTimestamp().After(it[i].GetCreationTimestamp().Time)
+}
+func (it SortByCreationTimestamp) Swap(i, j int) {
+	it[i], it[j] = it[j], it[i]
+}

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/mod v0.7.0
 	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/oauth2 v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -401,6 +401,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
### Summary
The worker nodes can do a rolling upgrade when we switch their versions due to the underlying `Machinetemplates` machinery. For the control plane, a lot of providers use kubeadm which has an inbuilt feature for these upgrades. In microk8s, we now implement the rolling upgrades by comparing the machines' versions (Major and minor only) and rolling out new machines based on the newer version. We scale up and down one-by-one, roll out a new versioned machine, and remove an older version of the machine.

### Changes
We sort all the machines ob their creation timestamp and take the first machine in them to be the older version and the last to be the newer version. We then find out about the older machines and remove them (scale down by one). The reconciler then rolls out newer versioned machines and this goes until an equi-versioned machine equilibrium.
Once all the machines have the same version, the default scaling up and scaling down take place.