### PR TITLE
Fix missing delete secret RBAC rule for control plane provider

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -57,6 +57,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/control-plane-components.yaml
+++ b/control-plane-components.yaml
@@ -413,6 +413,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/microk8scontrolplane_controller.go
+++ b/controllers/microk8scontrolplane_controller.go
@@ -57,7 +57,7 @@ type MicroK8sControlPlaneReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,namespace=kube-system,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=rbac,resources=roles,namespace=kube-system,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=rbac,resources=rolebindings,namespace=kube-system,verbs=get;list;watch;create


### PR DESCRIPTION
### Summary

Control plane provider requires permissions to delete secrets to properly cleanup after deleting a cluster. Add this missing rule to the RBAC Role object.