### PR TITLE
Add in-place upgrades

### DIFF
--- a/api/v1beta1/microk8scontrolplane_types.go
+++ b/api/v1beta1/microk8scontrolplane_types.go
@@ -27,6 +27,11 @@ import (
 type UpgradeStrategyType string
 
 const (
+	// SmartUpgradeStrategyType is an upgrade strategy that
+	// performs an in-place upgrade of the control plane on non-HA clusters and
+	// a rolling upgrade on HA clusters.
+	SmartUpgradeStrategyType UpgradeStrategyType = "SmartUpgrade"
+
 	// InPlaceUpgradeStrategyType is an upgrade strategy that
 	// performs an in-place upgrade of the control plane.
 	InPlaceUpgradeStrategyType UpgradeStrategyType = "InPlaceUpgrade"
@@ -66,9 +71,9 @@ type MicroK8sControlPlaneSpec struct {
 
 	// UpgradeStrategy describes how to replace existing machines
 	// with new ones.
-	// Values can be: InPlaceUpgrade or RollingUpgrade.
+	// Values can be: InPlaceUpgrade, RollingUpgrade or SmartUpgrade.
 	// +optional
-	// +kubebuilder:validation:Enum=InPlaceUpgrade;RollingUpgrade
+	// +kubebuilder:validation:Enum=InPlaceUpgrade;RollingUpgrade;SmartUpgrade
 	UpgradeStrategy UpgradeStrategyType `json:"upgradeStrategy"`
 
 	// ControlPlaneConfig is the reference configs to be used for initializing and joining

--- a/api/v1beta1/microk8scontrolplane_types.go
+++ b/api/v1beta1/microk8scontrolplane_types.go
@@ -23,12 +23,26 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+// UpgradeStrategyType is a string representing the upgrade strategy.
+type UpgradeStrategyType string
+
+const (
+	// InPlaceUpgradeStrategyType is an upgrade strategy that
+	// performs an in-place upgrade of the control plane.
+	InPlaceUpgradeStrategyType UpgradeStrategyType = "InPlaceUpgrade"
+
+	// RollingUpdateStrategyType is an upgrade strategy that
+	// deletes the current control plane machine before creating
+	// a new one.
+	RollingUpgradeStrategyType UpgradeStrategyType = "RollingUpgrade"
+)
+
 const (
 	MicroK8sControlPlaneFinalizer = "microk8s.controlplane.cluster.x-k8s.io"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// MachineTemplate defines the metadata and infrastructure information
+// for control plane machines.
 type MachineTemplate struct {
 	// InfrastructureTemplate is a required reference to a custom resource
 	// offered by an infrastructure provider.
@@ -37,9 +51,7 @@ type MachineTemplate struct {
 
 // MicroK8sControlPlaneSpec defines the desired state of MicroK8sControlPlane
 type MicroK8sControlPlaneSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
+	// Replicas is the desired number of control-plane machine replicas.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
@@ -48,9 +60,19 @@ type MicroK8sControlPlaneSpec struct {
 	// +kubebuilder:validation:Pattern:=^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$
 	Version string `json:"version"`
 
+	// MachineTemplate is the machine template to be used for
+	// creating control plane machines.
 	MachineTemplate `json:"machineTemplate"`
 
-	// to use for initializing and joining machines to the control plane.
+	// UpgradeStrategy describes how to replace existing machines
+	// with new ones.
+	// Values can be: InPlaceUpgrade or RollingUpgrade.
+	// +optional
+	// +kubebuilder:validation:Enum=InPlaceUpgrade;RollingUpgrade
+	UpgradeStrategy UpgradeStrategyType `json:"upgradeStrategy"`
+
+	// ControlPlaneConfig is the reference configs to be used for initializing and joining
+	// machines to the control plane.
 	// +optional
 	ControlPlaneConfig v1beta1.MicroK8sConfigSpec `json:"controlPlaneConfig,omitempty"`
 }

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
@@ -64,8 +64,8 @@ spec:
             description: MicroK8sControlPlaneSpec defines the desired state of MicroK8sControlPlane
             properties:
               controlPlaneConfig:
-                description: to use for initializing and joining machines to the control
-                  plane.
+                description: ControlPlaneConfig is the reference configs to be used
+                  for initializing and joining machines to the control plane.
                 properties:
                   clusterConfiguration:
                     description: InitConfiguration along with ClusterConfiguration
@@ -181,9 +181,8 @@ spec:
                     type: object
                 type: object
               machineTemplate:
-                description: 'EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-                  NOTE: json tags are required.  Any new fields you add must have
-                  json tags for the fields to be serialized.'
+                description: MachineTemplate is the machine template to be used for
+                  creating control plane machines.
                 properties:
                   infrastructureTemplate:
                     description: InfrastructureTemplate is a required reference to
@@ -227,8 +226,17 @@ spec:
                 - infrastructureTemplate
                 type: object
               replicas:
+                description: Replicas is the desired number of control-plane machine
+                  replicas.
                 format: int32
                 type: integer
+              upgradeStrategy:
+                description: 'UpgradeStrategy describes how to replace existing machines
+                  with new ones. Values can be: InPlaceUpgrade or RollingUpgrade.'
+                enum:
+                - InPlaceUpgrade
+                - RollingUpgrade
+                type: string
               version:
                 description: Version defines the desired Kubernetes version.
                 minLength: 2

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: microk8scontrolplanes.controlplane.cluster.x-k8s.io
 spec:
@@ -221,6 +221,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                 required:
                 - infrastructureTemplate
                 type: object
@@ -351,9 +352,3 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: microk8scontrolplanes.controlplane.cluster.x-k8s.io
 spec:
@@ -221,7 +221,6 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                 required:
                 - infrastructureTemplate
                 type: object
@@ -232,10 +231,12 @@ spec:
                 type: integer
               upgradeStrategy:
                 description: 'UpgradeStrategy describes how to replace existing machines
-                  with new ones. Values can be: InPlaceUpgrade or RollingUpgrade.'
+                  with new ones. Values can be: InPlaceUpgrade, RollingUpgrade or
+                  SmartUpgrade.'
                 enum:
                 - InPlaceUpgrade
                 - RollingUpgrade
+                - SmartUpgrade
                 type: string
               version:
                 description: Version defines the desired Kubernetes version.
@@ -350,3 +351,9 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
**Summary**
Add in-place upgrades for both the control plane and worker nodes.
For making the changes, we traverse all the nodes and create a  pod that gets attached to the nodes, the pod connects via a UNIX socket to the spapd daemon and passes and snap upgrade request using the snap REST API.  When the nodes are upgraded, we upgrade the corresponding machine and remove the pod.

**Changes**
Introduce a new field `UpgradeStrategyType` in `MicroK8sControlPlaneSpec` to explicitly define the upgrade strategy to apply.