### PR TITLE
Modify control plane controller manger to include upgradeStrategy field

### DIFF
--- a/control-plane-components.yaml
+++ b/control-plane-components.yaml
@@ -34,11 +34,13 @@ spec:
       jsonPath: .status.ready
       name: Ready
       type: boolean
-    - description: This denotes whether or not the control plane has the uploaded microk8s-config configmap
+    - description: This denotes whether or not the control plane has the uploaded
+        microk8s-config configmap
       jsonPath: .status.initialized
       name: Initialized
       type: boolean
-    - description: Total number of non-terminated machines targeted by this control plane
+    - description: Total number of non-terminated machines targeted by this control
+        plane
       jsonPath: .status.replicas
       name: Replicas
       type: integer
@@ -53,13 +55,18 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: MicroK8sControlPlane is the Schema for the microk8scontrolplanes API
+        description: MicroK8sControlPlane is the Schema for the microk8scontrolplanes
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -67,20 +74,31 @@ spec:
             description: MicroK8sControlPlaneSpec defines the desired state of MicroK8sControlPlane
             properties:
               controlPlaneConfig:
-                description: to use for initializing and joining machines to the control plane.
+                description: ControlPlaneConfig is the reference configs to be used
+                  for initializing and joining machines to the control plane.
                 properties:
                   clusterConfiguration:
-                    description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                    description: InitConfiguration along with ClusterConfiguration
+                      are the configurations necessary for the init command
                     properties:
                       apiVersion:
-                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                         type: string
                       kind:
-                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                         type: string
                       portCompatibilityRemap:
                         default: true
-                        description: PortCompatibilityRemap switches the default ports used by cluster agent (25000) and dqlite (19001) to 30000 and 2379. The default ports are blocked via security groups in several infra providers.
+                        description: PortCompatibilityRemap switches the default ports
+                          used by cluster agent (25000) and dqlite (19001) to 30000
+                          and 2379. The default ports are blocked via security groups
+                          in several infra providers.
                         type: boolean
                     type: object
                   initConfiguration:
@@ -94,7 +112,10 @@ spec:
                           type: string
                         type: array
                       apiVersion:
-                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                         type: string
                       confinement:
                         description: The confinement (strict or classic) configuration
@@ -103,14 +124,17 @@ spec:
                         - strict
                         type: string
                       extraKubeletArgs:
-                        description: ExtraKubeletArgs is a list of extra arguments to add to the kubelet.
+                        description: ExtraKubeletArgs is a list of extra arguments
+                          to add to the kubelet.
                         items:
                           type: string
                         type: array
                       extraWriteFiles:
-                        description: ExtraWriteFiles is a list of extra files to inject with cloud-init.
+                        description: ExtraWriteFiles is a list of extra files to inject
+                          with cloud-init.
                         items:
-                          description: CloudInitWriteFile is a file that will be injected by cloud-init
+                          description: CloudInitWriteFile is a file that will be injected
+                            by cloud-init
                           properties:
                             content:
                               description: Content of the file to create.
@@ -122,7 +146,8 @@ spec:
                               description: Path where the file should be created.
                               type: string
                             permissions:
-                              description: Permissions of the file to create, e.g. "0600"
+                              description: Permissions of the file to create, e.g.
+                                "0600"
                               type: string
                           required:
                           - content
@@ -139,19 +164,24 @@ spec:
                         type: string
                       joinTokenTTLInSecs:
                         default: 315569260
-                        description: The join token will expire after the specified seconds, defaults to 10 years
+                        description: The join token will expire after the specified
+                          seconds, defaults to 10 years
                         format: int64
                         minimum: 1
                         type: integer
                       kind:
-                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                         type: string
                       noProxy:
                         description: The optional no proxy configuration
                         type: string
                       riskLevel:
                         default: stable
-                        description: The risk-level (stable, candidate, beta, or edge) for the snaps
+                        description: The risk-level (stable, candidate, beta, or edge)
+                          for the snaps
                         enum:
                         - stable
                         - candidate
@@ -161,16 +191,28 @@ spec:
                     type: object
                 type: object
               machineTemplate:
-                description: 'EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN! NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.'
+                description: MachineTemplate is the machine template to be used for
+                  creating control plane machines.
                 properties:
                   infrastructureTemplate:
-                    description: InfrastructureTemplate is a required reference to a custom resource offered by an infrastructure provider.
+                    description: InfrastructureTemplate is a required reference to
+                      a custom resource offered by an infrastructure provider.
                     properties:
                       apiVersion:
                         description: API version of the referent.
                         type: string
                       fieldPath:
-                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
                         type: string
                       kind:
                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -182,7 +224,8 @@ spec:
                         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                         type: string
                       resourceVersion:
-                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                         type: string
                       uid:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -193,8 +236,19 @@ spec:
                 - infrastructureTemplate
                 type: object
               replicas:
+                description: Replicas is the desired number of control-plane machine
+                  replicas.
                 format: int32
                 type: integer
+              upgradeStrategy:
+                description: 'UpgradeStrategy describes how to replace existing machines
+                  with new ones. Values can be: InPlaceUpgrade, RollingUpgrade or
+                  SmartUpgrade.'
+                enum:
+                - InPlaceUpgrade
+                - RollingUpgrade
+                - SmartUpgrade
+                type: string
               version:
                 description: Version defines the desired Kubernetes version.
                 minLength: 2
@@ -205,34 +259,52 @@ spec:
             - version
             type: object
           status:
-            description: MicroK8sControlPlaneStatus defines the observed state of MicroK8sControlPlane
+            description: MicroK8sControlPlaneStatus defines the observed state of
+              MicroK8sControlPlane
             properties:
               bootstrapped:
-                description: Bootstrapped denotes whether any nodes received bootstrap request which is required to start etcd and Kubernetes components in MicroK8s.
+                description: Bootstrapped denotes whether any nodes received bootstrap
+                  request which is required to start etcd and Kubernetes components
+                  in MicroK8s.
                 type: boolean
               conditions:
                 description: Conditions defines current service state of the MicroK8sControlPlane.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -241,28 +313,43 @@ spec:
                   type: object
                 type: array
               initialized:
-                description: Initialized denotes whether or not the control plane has the uploaded microk8s-config configmap.
+                description: Initialized denotes whether or not the control plane
+                  has the uploaded microk8s-config configmap.
                 type: boolean
               observedGeneration:
-                description: ObservedGeneration is the latest generation observed by the controller.
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
                 format: int64
                 type: integer
               ready:
-                description: Ready denotes that the MicroK8sControlPlane API Server is ready to receive requests.
+                description: Ready denotes that the MicroK8sControlPlane API Server
+                  is ready to receive requests.
                 type: boolean
               readyReplicas:
-                description: Total number of fully running and ready control plane machines.
+                description: Total number of fully running and ready control plane
+                  machines.
                 format: int32
                 type: integer
               replicas:
-                description: Total number of non-terminated machines targeted by this control plane (their labels match the selector).
+                description: Total number of non-terminated machines targeted by this
+                  control plane (their labels match the selector).
                 format: int32
                 type: integer
               selector:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file Selector is the label selector in string format to avoid
+                  introspection by clients, and is used to provide the CRD-based integration
+                  for the scale subresource and additional integrations for things
+                  like kubectl describe.. The string will be in the same format as
+                  the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
                 type: string
               unavailableReplicas:
-                description: Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.
+                description: Total number of unavailable machines targeted by this
+                  control plane. This is the total number of machines that are still
+                  required for the deployment to have 100% available capacity. They
+                  may either be machines that are running but not yet ready or machines
+                  that still have not been created.
                 format: int32
                 type: integer
             type: object


### PR DESCRIPTION
### Summary

Based on https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/pull/65
The new manager manifest now includes the `upgradeStrategy` field. Also, some formatting fixes after `make component`.

### Note 

After this `upgradeStrategy` filed becomes mandatory to set.