### PR TITLE
Add lables to kubeconfig secrets for CAPI 1.5 compatibility

### DIFF
--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -105,6 +105,9 @@ func (r *MicroK8sControlPlaneReconciler) kubeconfigForCluster(ctx context.Contex
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cluster.Namespace,
 				Name:      cluster.Name + "-kubeconfig",
+				Labels: map[string]string{
+					"cluster.x-k8s.io/cluster-name": cluster.Name,
+				},
 			},
 			Data: map[string][]byte{
 				"value": []byte(*kubeconfig),


### PR DESCRIPTION
For 1.5 migrations, changes in how the control plane attaches labels to the `kubeconfig-secret` must be changed. More info here: https://cluster-api.sigs.k8s.io/developer/architecture/controllers/control-plane#kubeconfig-management

This is due to changes in how upstream CAPI caches secrets: https://github.com/kubernetes-sigs/cluster-api/pull/8940

Fixes https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/issues/75
