### PR TITLE
Add required label to kubeconfig

### DIFF
--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -105,6 +105,9 @@ func (r *MicroK8sControlPlaneReconciler) kubeconfigForCluster(ctx context.Contex
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cluster.Namespace,
 				Name:      cluster.Name + "-kubeconfig",
+				Labels: map[string]string{
+					clusterv1.ClusterLabelName: cluster.Name,
+				},
 			},
 			Data: map[string][]byte{
 				"value": []byte(*kubeconfig),


### PR DESCRIPTION
### Summary

Closes #43 

### Notes

ClusterAPI 1.5.0 and newer requires that the workload cluster kubeconfig has a label set with the cluster name, otherwise it fails to recognise it.
