### PR TITLE
Fix external machine labels

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -351,6 +351,10 @@ func (r *MicroK8sControlPlaneReconciler) bootControlPlane(ctx context.Context, c
 		Namespace:   mcp.Namespace,
 		OwnerRef:    infraCloneOwner,
 		ClusterName: cluster.Name,
+		Labels: map[string]string{
+			clusterv1.ClusterLabelName:             cluster.Name,
+			clusterv1.MachineControlPlaneLabelName: "",
+		},
 	})
 	if err != nil {
 		conditions.MarkFalse(mcp, clusterv1beta1.MachinesCreatedCondition,


### PR DESCRIPTION
#### Summary

External control plane machines must be labelled with the cluster name and as control plane nodes, otherwise some providers do not handle them properly.

This is required for the MaaS cluster template (https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/pull/77) to properly configure DNS for the cluster endpoint.