### PR TITLE
CP is Ready if no nodes are Ready

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -94,13 +94,12 @@ func (r *MicroK8sControlPlaneReconciler) updateStatus(ctx context.Context, mcp *
 	if len(nodes.Items) > 0 {
 		mcp.Status.Initialized = true
 		conditions.MarkTrue(mcp, clusterv1beta1.AvailableCondition)
-	}
 
-	if mcp.Status.ReadyReplicas > 0 {
+		// The control plane is Ready to receive requests
 		mcp.Status.Ready = true
 	}
 
-	logger.WithValues("count", mcp.Status.ReadyReplicas).Info("ready replicas")
+	logger.WithValues("ready", mcp.Status.Ready, "count", mcp.Status.ReadyReplicas).Info("ready replicas")
 
 	return nil
 }


### PR DESCRIPTION
### Summary

Mark the control plane status as Ready when we start getting API responses, not after there are Ready nodes. 