### PR TITLE
add new disableDefaultCNI field

### DIFF
--- a/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
@@ -120,6 +120,9 @@ spec:
                         - classic
                         - strict
                         type: string
+                      disableDefaultCNI:
+                        description: Whether or not to use the default CNI
+                        type: boolean
                       extraKubeletArgs:
                         description: ExtraKubeletArgs is a list of extra arguments
                           to add to the kubelet.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/cluster-api-control-plane-provider-microk8s
 go 1.21
 
 require (
-	github.com/canonical/cluster-api-bootstrap-provider-microk8s v0.6.0-api.1
+	github.com/canonical/cluster-api-bootstrap-provider-microk8s v0.6.9-api
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.22.1
 	k8s.io/api v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/canonical/cluster-api-bootstrap-provider-microk8s v0.6.0-api.1 h1:t/qqh9l44Ci+aZsk67k5kCv9xrLCD6Le4GfVr5hze8o=
-github.com/canonical/cluster-api-bootstrap-provider-microk8s v0.6.0-api.1/go.mod h1:tVGQG1UKgtBqnyO1a50LtnzlvWtYqcZbNmJ4SjEEMnI=
+github.com/canonical/cluster-api-bootstrap-provider-microk8s v0.6.9-api h1:wlS8dXLofkWI2rHlgr6U/iviwBXWPl93t/0064uV880=
+github.com/canonical/cluster-api-bootstrap-provider-microk8s v0.6.9-api/go.mod h1:U/c+efAG83sqU+L502RgtfS8v7VOYCWEg3LNbJYFQz0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
This PR adds the field created in the `v0.6.9-api` tag of cluster-api-boostrap-provider-microk8s.

See https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/pull/109