### PR TITLE
Call node removal endpoint on machine deletion

### DIFF
--- a/pkg/clusteragent/clusteragent.go
+++ b/pkg/clusteragent/clusteragent.go
@@ -14,7 +14,10 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-const defaultClusterAgentPort = "25000"
+const (
+	defaultClusterAgentPort = "25000"
+	defaultTimeout          = 10 * time.Second
+)
 
 // Options should be used when initializing a new client.
 type Options struct {
@@ -24,6 +27,8 @@ type Options struct {
 	Port string
 	// InsecureSkipVerify skips the verification of the server's certificate chain and host name.
 	InsecureSkipVerify bool
+	// Timeout is the maximum amount of time a request is allowed to take.
+	Timeout time.Duration
 }
 
 type Client struct {
@@ -53,6 +58,11 @@ func NewClient(machines []clusterv1.Machine, opts Options) (*Client, error) {
 		port = opts.Port
 	}
 
+	timeout := defaultTimeout
+	if opts.Timeout != 0 {
+		timeout = opts.Timeout
+	}
+
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: opts.InsecureSkipVerify,
@@ -63,7 +73,7 @@ func NewClient(machines []clusterv1.Machine, opts Options) (*Client, error) {
 		ip:   ip,
 		port: port,
 		client: &http.Client{
-			Timeout:   30 * time.Second,
+			Timeout:   timeout,
 			Transport: transport,
 		},
 	}, nil

--- a/pkg/clusteragent/clusteragent.go
+++ b/pkg/clusteragent/clusteragent.go
@@ -1,0 +1,117 @@
+package clusteragent
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+const defaultClusterAgentPort = "25000"
+
+// Options should be used when initializing a new client.
+type Options struct {
+	// IgnoreNodeIPs is a set of ignored IPs that we don't want to pick for the cluster agent endpoint.
+	IgnoreNodeIPs sets.String
+	// Port overwrites the default cluster agent port to connect.
+	Port string
+	// InsecureSkipVerify skips the verification of the server's certificate chain and host name.
+	InsecureSkipVerify bool
+}
+
+type Client struct {
+	ip, port string
+	client   *http.Client
+}
+
+// NewClient picks an IP from one of the given machines and creates a new client for the cluster agent
+// with that IP.
+func NewClient(machines []clusterv1.Machine, opts Options) (*Client, error) {
+	var ip string
+	for _, m := range machines {
+		for _, addr := range m.Status.Addresses {
+			if !opts.IgnoreNodeIPs.Has(addr.Address) {
+				ip = addr.Address
+				break
+			}
+		}
+	}
+
+	if ip == "" {
+		return nil, errors.New("failed to find an IP for cluster agent")
+	}
+
+	port := defaultClusterAgentPort
+	if opts.Port != "" {
+		port = opts.Port
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: opts.InsecureSkipVerify,
+		},
+	}
+
+	return &Client{
+		ip:   ip,
+		port: port,
+		client: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: transport,
+		},
+	}, nil
+}
+
+func (c *Client) Endpoint() string {
+	return fmt.Sprintf("https://%s:%s", c.ip, c.port)
+}
+
+// Do makes a request to the given endpoint with the given method. It marshals the request and unmarshals
+// server response body if the provided response is not nil.
+// The endpoint should _not_ have a leading slash.
+func (c *Client) Do(ctx context.Context, method, endpoint string, request any, response any) error {
+	url := fmt.Sprintf("https://%s:%s/%s", c.ip, c.port, endpoint)
+
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("failed to prepare worker info request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call cluster agent: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		// NOTE(hue): Marshal and print any response that we got since it might contain valuable information
+		// on why the request failed.
+		// Ignore JSON errors to prevent unnecessarily complicated error handling.
+		anyResp := make(map[string]any)
+		_ = json.NewDecoder(res.Body).Decode(&anyResp)
+		b, _ := json.Marshal(anyResp)
+		resStr := string(b)
+
+		return fmt.Errorf("HTTP request to cluster agent failed with status code %d, got response: %q", res.StatusCode, resStr)
+	}
+
+	if response != nil {
+		if err := json.NewDecoder(res.Body).Decode(response); err != nil {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/clusteragent/clusteragent_test.go
+++ b/pkg/clusteragent/clusteragent_test.go
@@ -1,0 +1,184 @@
+package clusteragent_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/canonical/cluster-api-control-plane-provider-microk8s/pkg/clusteragent"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestClient(t *testing.T) {
+	t.Run("CanNotFindAddress", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Machines don't have any addresses.
+		machines := []clusterv1.Machine{{}, {}}
+		_, err := clusteragent.NewClient(machines, clusteragent.Options{})
+
+		g.Expect(err).To(HaveOccurred())
+
+		// The only machine is the ignored one.
+		addr := "1.1.1.1"
+		machines = []clusterv1.Machine{
+			{
+				Status: clusterv1.MachineStatus{
+					Addresses: clusterv1.MachineAddresses{
+						{
+							Address: addr,
+						},
+					},
+				},
+			},
+		}
+		_, err = clusteragent.NewClient(machines, clusteragent.Options{IgnoreNodeIPs: sets.NewString(addr)})
+
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("CorrectEndpoint", func(t *testing.T) {
+		g := NewWithT(t)
+
+		port := "30000"
+		firstAddr := "1.1.1.1"
+		secondAddr := "2.2.2.2"
+		thirdAddr := "3.3.3.3"
+		ignoreAddr := "8.8.8.8"
+		machines := []clusterv1.Machine{
+			{
+				Status: clusterv1.MachineStatus{
+					Addresses: clusterv1.MachineAddresses{
+						{
+							Address: firstAddr,
+						},
+					},
+				},
+			},
+			{
+				Status: clusterv1.MachineStatus{
+					Addresses: clusterv1.MachineAddresses{
+						{
+							Address: secondAddr,
+						},
+					},
+				},
+			},
+			{
+				Status: clusterv1.MachineStatus{
+					Addresses: clusterv1.MachineAddresses{
+						{
+							Address: thirdAddr,
+						},
+					},
+				},
+			},
+		}
+
+		opts := clusteragent.Options{
+			IgnoreNodeIPs: sets.NewString(ignoreAddr),
+			Port:          port,
+		}
+
+		// NOTE(Hue): Repeat the test to make sure the IP is not picked by chance (reduce flakiness).
+		for i := 0; i < 30; i++ {
+			c, err := clusteragent.NewClient(machines, opts)
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Check if the endpoint is one of the expected ones and not the ignored one.
+			g.Expect([]string{fmt.Sprintf("https://%s:%s", firstAddr, port), fmt.Sprintf("https://%s:%s", secondAddr, port), fmt.Sprintf("https://%s:%s", thirdAddr, port)}).To(ContainElement(c.Endpoint()))
+			g.Expect(c.Endpoint()).ToNot(Equal(fmt.Sprintf("https://%s:%s", ignoreAddr, port)))
+		}
+
+	})
+}
+
+func TestDo(t *testing.T) {
+	g := NewWithT(t)
+
+	path := "/random/path"
+	method := http.MethodPost
+	resp := map[string]string{
+		"key": "value",
+	}
+	servM := NewServerMock(method, path, resp)
+	defer servM.ts.Close()
+
+	ip, port, err := net.SplitHostPort(strings.TrimPrefix(servM.ts.URL, "https://"))
+	g.Expect(err).ToNot(HaveOccurred())
+	c, err := clusteragent.NewClient([]clusterv1.Machine{
+		{
+			Status: clusterv1.MachineStatus{
+				Addresses: clusterv1.MachineAddresses{
+					{
+						Address: ip,
+					},
+				},
+			},
+		},
+	}, clusteragent.Options{Port: port, InsecureSkipVerify: true})
+
+	g.Expect(err).ToNot(HaveOccurred())
+
+	response := make(map[string]string)
+	req := map[string]string{"req": "value"}
+	path = strings.TrimPrefix(path, "/")
+	g.Expect(c.Do(context.Background(), method, path, req, &response)).To(Succeed())
+
+	g.Expect(response).To(Equal(resp))
+}
+
+type serverMock struct {
+	method   string
+	path     string
+	response any
+	request  map[string]any
+	ts       *httptest.Server
+}
+
+// NewServerMock creates a test server that responds with the given response when called with the given method and path.
+// Make sure to close the server after the test is done.
+// Server will try to decode the request body into a map[string]any.
+func NewServerMock(method string, path string, response any) *serverMock {
+	req := make(map[string]any)
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != method {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if response != nil {
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	return &serverMock{
+		method:   method,
+		path:     path,
+		response: response,
+		request:  req,
+		ts:       ts,
+	}
+}

--- a/pkg/clusteragent/remove_node.go
+++ b/pkg/clusteragent/remove_node.go
@@ -1,0 +1,13 @@
+package clusteragent
+
+import (
+	"context"
+	"net/http"
+)
+
+// RemoveNodeFromDqlite calls the /v2/dqlite/remove endpoint on cluster agent to remove the given address from Dqlite.
+// The endpoint should be in the format of "address:port".
+func (p *Client) RemoveNodeFromDqlite(ctx context.Context, removeEp string) error {
+	request := map[string]string{"removeEndpoint": removeEp}
+	return p.Do(ctx, http.MethodPost, "cluster/api/v2.0/dqlite/remove", request, nil)
+}

--- a/pkg/clusteragent/remove_node_test.go
+++ b/pkg/clusteragent/remove_node_test.go
@@ -1,0 +1,41 @@
+package clusteragent_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/canonical/cluster-api-control-plane-provider-microk8s/pkg/clusteragent"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestRemoveFromDqlite(t *testing.T) {
+	g := NewWithT(t)
+
+	path := "/cluster/api/v2.0/dqlite/remove"
+	method := http.MethodPost
+	servM := NewServerMock(method, path, nil)
+	defer servM.ts.Close()
+
+	ip, port, err := net.SplitHostPort(strings.TrimPrefix(servM.ts.URL, "https://"))
+	g.Expect(err).ToNot(HaveOccurred())
+	c, err := clusteragent.NewClient([]clusterv1.Machine{
+		{
+			Status: clusterv1.MachineStatus{
+				Addresses: clusterv1.MachineAddresses{
+					{
+						Address: ip,
+					},
+				},
+			},
+		},
+	}, clusteragent.Options{Port: port, InsecureSkipVerify: true})
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(c.RemoveNodeFromDqlite(context.Background(), "1.1.1.1:1234")).To(Succeed())
+	g.Expect(servM.request).To(HaveKeyWithValue("removeEndpoint", "1.1.1.1:1234"))
+}

--- a/pkg/clusteragent/remove_node_test.go
+++ b/pkg/clusteragent/remove_node_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -33,7 +34,7 @@ func TestRemoveFromDqlite(t *testing.T) {
 				},
 			},
 		},
-	}, clusteragent.Options{Port: port, InsecureSkipVerify: true})
+	}, port, time.Second, clusteragent.Options{InsecureSkipVerify: true})
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(c.RemoveNodeFromDqlite(context.Background(), "1.1.1.1:1234")).To(Succeed())


### PR DESCRIPTION
### Summary
Related to: https://github.com/canonical/microk8s-cluster-agent/pull/55
After implementing the `Remove` endpoint in the `microk8s-cluster-agent`, now we need to call it from the control plane provider to make sure the node is also getting removed from the Dqlite cluster. This PR addresses the issue that node entries were still available in the `${SNAP_DATA}/var/kubernetes/backend/cluster.yaml` file even after they left (i.e. were deleted by the CAPI providers). 

### Note
Another machine deletion happens when we observe the deletion timestamp on the `Cluster` object. While this might sound like another place to call `Remove` endpoint of the cluster-agent in, we are safe without doing so since cluster deletion means there would be no node left after the fact (i.e. no faulty `cluster.yaml` file anyways).
Also, we do this step as a best effort since this whole logic is implemented to prevent a not-yet-reported bug.