### PR TITLE
Add pkg to Dockerfile and Fix TLS issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$arch go build -a -ldflags '-s -w' -o manager main.go

--- a/pkg/clusteragent/clusteragent_test.go
+++ b/pkg/clusteragent/clusteragent_test.go
@@ -145,7 +145,7 @@ func TestDo(t *testing.T) {
 				},
 			},
 		},
-	}, port, time.Second, clusteragent.Options{InsecureSkipVerify: true})
+	}, port, time.Second, clusteragent.Options{})
 
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/clusteragent/remove_node_test.go
+++ b/pkg/clusteragent/remove_node_test.go
@@ -34,7 +34,7 @@ func TestRemoveFromDqlite(t *testing.T) {
 				},
 			},
 		},
-	}, port, time.Second, clusteragent.Options{InsecureSkipVerify: true})
+	}, port, time.Second, clusteragent.Options{})
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(c.RemoveNodeFromDqlite(context.Background(), "1.1.1.1:1234")).To(Succeed())


### PR DESCRIPTION
Without this change we won't be able to run `docker build` since we're first copying files and then running `go build` in the Dockerfile.

The `InsecureSkipVerify: true` workaround is something that we also have in k8s-snap CAPI right now as well: https://github.com/canonical/cluster-api-k8s/blob/main/pkg/ck8s/workload_cluster_k8sd.go#L116