### PR TITLE
Add capi-auth-token header to /dqlite/remove request

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -595,8 +595,10 @@ func (r *MicroK8sControlPlaneReconciler) scaleDownControlPlane(ctx context.Conte
 	// The issue is that we were not removing the endpoint from dqlite when we were deleting a machine.
 	// This would cause a situation were a joining node failed to join because the endpoint was already in the dqlite cluster.
 	// How? The IP assigned to the joining (new) node, previously belonged to a node that was deleted, but the IP is still there in dqlite.
-	// If we have 2 or more machines left, get cluster agent client and delete node from dqlite
-	if len(machines) > 1 {
+	// If we have 2 machines, deleting one is not safe because it can be the leader and we're not taking care of
+	// leadership transfers in the cluster-agent for now. Maybe something for later (TODO)
+	// If we have 3 or more machines left, get cluster agent client and delete node from dqlite.
+	if len(machines) > 2 {
 		portRemap := tcp != nil && tcp.Spec.ControlPlaneConfig.ClusterConfiguration != nil && tcp.Spec.ControlPlaneConfig.ClusterConfiguration.PortCompatibilityRemap
 
 		if clusterAgentClient, err := getClusterAgentClient(machines, deleteMachine, portRemap); err == nil {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	cloud.google.com/go/compute v1.10.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect

--- a/pkg/clusteragent/clusteragent.go
+++ b/pkg/clusteragent/clusteragent.go
@@ -69,10 +69,10 @@ func (c *Client) Endpoint() string {
 	return fmt.Sprintf("https://%s:%s", c.ip, c.port)
 }
 
-// Do makes a request to the given endpoint with the given method. It marshals the request and unmarshals
+// do makes a request to the given endpoint with the given method. It marshals the request and unmarshals
 // server response body if the provided response is not nil.
 // The endpoint should _not_ have a leading slash.
-func (c *Client) Do(ctx context.Context, method, endpoint string, request any, response any) error {
+func (c *Client) do(ctx context.Context, method, endpoint string, request any, header map[string][]string, response any) error {
 	url := fmt.Sprintf("https://%s:%s/%s", c.ip, c.port, endpoint)
 
 	requestBody, err := json.Marshal(request)
@@ -84,6 +84,8 @@ func (c *Client) Do(ctx context.Context, method, endpoint string, request any, r
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
+
+	req.Header = http.Header(header)
 
 	res, err := c.client.Do(req)
 	if err != nil {

--- a/pkg/clusteragent/const.go
+++ b/pkg/clusteragent/const.go
@@ -1,0 +1,5 @@
+package clusteragent
+
+const (
+	AuthTokenHeader = "capi-auth-token"
+)

--- a/pkg/clusteragent/remove_node.go
+++ b/pkg/clusteragent/remove_node.go
@@ -9,5 +9,12 @@ import (
 // The endpoint should be in the format of "address:port".
 func (p *Client) RemoveNodeFromDqlite(ctx context.Context, removeEp string) error {
 	request := map[string]string{"removeEndpoint": removeEp}
-	return p.Do(ctx, http.MethodPost, "cluster/api/v2.0/dqlite/remove", request, nil)
+
+	// // TODO(Hue): change the token
+	// callbackToken := "myRandomToken"
+	// header := map[string][]string{
+	// 	"callback_token": {callbackToken},
+	// }
+
+	return p.do(ctx, http.MethodPost, "cluster/api/v2.0/dqlite/remove", request, nil, nil)
 }

--- a/pkg/clusteragent/remove_node.go
+++ b/pkg/clusteragent/remove_node.go
@@ -7,14 +7,10 @@ import (
 
 // RemoveNodeFromDqlite calls the /v2/dqlite/remove endpoint on cluster agent to remove the given address from Dqlite.
 // The endpoint should be in the format of "address:port".
-func (p *Client) RemoveNodeFromDqlite(ctx context.Context, removeEp string) error {
-	request := map[string]string{"removeEndpoint": removeEp}
-
-	// // TODO(Hue): change the token
-	// callbackToken := "myRandomToken"
-	// header := map[string][]string{
-	// 	"callback_token": {callbackToken},
-	// }
-
-	return p.do(ctx, http.MethodPost, "cluster/api/v2.0/dqlite/remove", request, nil, nil)
+func (p *Client) RemoveNodeFromDqlite(ctx context.Context, token string, removeEp string) error {
+	request := map[string]string{"remove_endpoint": removeEp}
+	header := map[string][]string{
+		AuthTokenHeader: {token},
+	}
+	return p.do(ctx, http.MethodPost, "cluster/api/v2.0/dqlite/remove", request, header, nil)
 }

--- a/pkg/clusteragent/remove_node_test.go
+++ b/pkg/clusteragent/remove_node_test.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/canonical/cluster-api-control-plane-provider-microk8s/pkg/clusteragent"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"github.com/canonical/cluster-api-control-plane-provider-microk8s/pkg/httptest"
 )
 
 func TestRemoveFromDqlite(t *testing.T) {
@@ -19,10 +20,10 @@ func TestRemoveFromDqlite(t *testing.T) {
 
 	path := "/cluster/api/v2.0/dqlite/remove"
 	method := http.MethodPost
-	servM := NewServerMock(method, path, nil)
-	defer servM.ts.Close()
+	servM := httptest.NewServerMock(method, path, nil)
+	defer servM.Srv.Close()
 
-	ip, port, err := net.SplitHostPort(strings.TrimPrefix(servM.ts.URL, "https://"))
+	ip, port, err := net.SplitHostPort(strings.TrimPrefix(servM.Srv.URL, "https://"))
 	g.Expect(err).ToNot(HaveOccurred())
 	c, err := clusteragent.NewClient([]clusterv1.Machine{
 		{
@@ -38,5 +39,7 @@ func TestRemoveFromDqlite(t *testing.T) {
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(c.RemoveNodeFromDqlite(context.Background(), "1.1.1.1:1234")).To(Succeed())
-	g.Expect(servM.request).To(HaveKeyWithValue("removeEndpoint", "1.1.1.1:1234"))
+	g.Expect(servM.Request).To(HaveKeyWithValue("removeEndpoint", "1.1.1.1:1234"))
+	// // TODO(Hue): change the token
+	// g.Expect(servM.Header.Get("callback_token")).To(Equal("myRandomToken"))
 }

--- a/pkg/clusteragent/remove_node_test.go
+++ b/pkg/clusteragent/remove_node_test.go
@@ -19,6 +19,7 @@ func TestRemoveFromDqlite(t *testing.T) {
 	g := NewWithT(t)
 
 	path := "/cluster/api/v2.0/dqlite/remove"
+	token := "myRandomToken"
 	method := http.MethodPost
 	servM := httptest.NewServerMock(method, path, nil)
 	defer servM.Srv.Close()
@@ -38,8 +39,7 @@ func TestRemoveFromDqlite(t *testing.T) {
 	}, port, time.Second, clusteragent.Options{})
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(c.RemoveNodeFromDqlite(context.Background(), "1.1.1.1:1234")).To(Succeed())
-	g.Expect(servM.Request).To(HaveKeyWithValue("removeEndpoint", "1.1.1.1:1234"))
-	// // TODO(Hue): change the token
-	// g.Expect(servM.Header.Get("callback_token")).To(Equal("myRandomToken"))
+	g.Expect(c.RemoveNodeFromDqlite(context.Background(), token, "1.1.1.1:1234")).To(Succeed())
+	g.Expect(servM.Request).To(HaveKeyWithValue("remove_endpoint", "1.1.1.1:1234"))
+	g.Expect(servM.Header.Get(clusteragent.AuthTokenHeader)).To(Equal(token))
 }

--- a/pkg/httptest/httptest.go
+++ b/pkg/httptest/httptest.go
@@ -1,0 +1,62 @@
+package httptest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+)
+
+type serverMock struct {
+	Method   string
+	Path     string
+	Response any
+	Request  map[string]any
+	Header   http.Header
+	Srv      *httptest.Server
+}
+
+// NewServerMock creates a test server that responds with the given response when called with the given method and path.
+// Make sure to close the server after the test is done.
+// Server will try to decode the request body into a map[string]any.
+func NewServerMock(method string, path string, response any) *serverMock {
+	req := make(map[string]any)
+	header := make(map[string][]string)
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != method {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		for k, vv := range map[string][]string(r.Header) {
+			header[k] = vv
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if response != nil {
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	fmt.Println("header:", header)
+	return &serverMock{
+		Method:   method,
+		Path:     path,
+		Response: response,
+		Header:   header,
+		Request:  req,
+		Srv:      ts,
+	}
+}

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -41,7 +41,7 @@ func getSecret(ctx context.Context, c client.Client, clusterKey client.ObjectKey
 	return s, nil
 }
 
-// name returns the name of the token secret, computed by convention using the name of the cluster.
+// authTokenName returns the name of the auth-token secret, computed by convention using the name of the cluster.
 func authTokenName(clusterName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, AuthTokenNameSuffix)
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -1,0 +1,47 @@
+package token
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	AuthTokenNameSuffix = "capi-auth-token"
+)
+
+// Lookup retrieves the token for the given cluster.
+func Lookup(ctx context.Context, c client.Client, clusterKey client.ObjectKey) (string, error) {
+	secret, err := getSecret(ctx, c, clusterKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret: %w", err)
+	}
+
+	v, ok := secret.Data["token"]
+	if !ok {
+		return "", fmt.Errorf("token not found in secret")
+	}
+
+	return string(v), nil
+}
+
+// getSecret retrieves the token secret for the given cluster.
+func getSecret(ctx context.Context, c client.Client, clusterKey client.ObjectKey) (*corev1.Secret, error) {
+	s := &corev1.Secret{}
+	key := client.ObjectKey{
+		Name:      authTokenName(clusterKey.Name),
+		Namespace: clusterKey.Namespace,
+	}
+	if err := c.Get(ctx, key, s); err != nil {
+		return nil, fmt.Errorf("failed to get secret: %w", err)
+	}
+
+	return s, nil
+}
+
+// name returns the name of the token secret, computed by convention using the name of the cluster.
+func authTokenName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, AuthTokenNameSuffix)
+}

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -1,0 +1,1 @@
+package token_test

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -1,1 +1,50 @@
 package token_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/canonical/cluster-api-control-plane-provider-microk8s/pkg/token"
+)
+
+func TestReconcile(t *testing.T) {
+	t.Run("LookupFailsIfNoSecret", func(t *testing.T) {
+		namespace := "test-namespace"
+		clusterName := "test-cluster"
+		c := fake.NewClientBuilder().Build()
+
+		g := NewWithT(t)
+
+		_, err := token.Lookup(context.Background(), c, client.ObjectKey{Name: clusterName, Namespace: namespace})
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("LookupSucceedsIfSecretExists", func(t *testing.T) {
+		namespace := "test-namespace"
+		clusterName := "test-cluster"
+		expToken := "test-token"
+		secret := &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", clusterName, token.AuthTokenNameSuffix),
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"token": []byte(expToken),
+			},
+		}
+		c := fake.NewClientBuilder().WithObjects(secret).Build()
+
+		g := NewWithT(t)
+
+		token, err := token.Lookup(context.Background(), c, client.ObjectKey{Name: clusterName, Namespace: namespace})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(token).To(Equal(expToken))
+	})
+}


### PR DESCRIPTION
### Summary
This PR adds the `capi-auth-token` header to the `dqlite/remove` request.
The `<cluster>-capi-auth-token` secret is supposed to be created by the Microk8s bootstrap provider. This coupling is (AFAIK) inevitable because we're having them in separate repos and the bootstrap provider is responsible for populating the `/capi/etc/token` file on the control plane machines.

- Also the `removeEndpoint` request field is changed to `remove_endpoint` to comply with the recent MAAS API guidelines.
- Minor other refactorings to improve the code structure.

### PR series
1. Cluster agent token validation --> https://github.com/canonical/microk8s-cluster-agent/pull/56
2. Microk8s bootstrap provider add token file and secret --> https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/pull/115
3. Microk8s control plane provider use token for request --> This one